### PR TITLE
EFO: remove compression threshold

### DIFF
--- a/nxontology_data/efo/efo.py
+++ b/nxontology_data/efo/efo.py
@@ -391,7 +391,7 @@ class EfoProcessor:
                 precision_df,
                 output_dir.joinpath(f"{self.name}_precision_classifications.json.gz"),
             )
-            write_ontology(nxo_slim, output_dir, compression_threshold_mb=30.0)
+            write_ontology(nxo_slim, output_dir)
 
     @staticmethod
     def create_slim_nxo(nxo: NXOntology[str]) -> NXOntology[str]:


### PR DESCRIPTION
With additional node attributes, we've exceeded the compression threshold. Remove `compression_threshold` to ensure we stick to the compressed JSON file.